### PR TITLE
HCK-7253: fix getting target script for documentation

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -18,10 +18,7 @@ module.exports = {
 					(data.entityData[entityId] || [])[0] || {},
 				),
 			);
-			if (
-				data.options.targetScriptOptions &&
-				data.options.targetScriptOptions.keyword === 'containerSettingsJson'
-			) {
+			if (data.options?.targetScriptOptions?.keyword === 'containerSettingsJson') {
 				const uniqueKeys = _.get(data.containerData, '[0].uniqueKey', []);
 				const scriptData = {
 					partitionKey: getPartitionKey(_)(data.containerData),
@@ -43,7 +40,6 @@ module.exports = {
 
 			const script = buildAzureCLIScript(_)({
 				...data,
-				shellName: data.options.targetScriptOptions.keyword.split('azureCli')[1].toLowerCase(),
 			});
 
 			if (withSamples || !insertSamplesOption.value) {

--- a/forward_engineering/helpers/azureCLIScriptHelpers/buildAzureCLIScript.js
+++ b/forward_engineering/helpers/azureCLIScriptHelpers/buildAzureCLIScript.js
@@ -4,6 +4,7 @@ const { getUniqueKeyPolicyScript } = require('../getUniqueKeyPolicyScript');
 const { getCliParamsDelimiter } = require('./getCliParamsDelimiter');
 const getIndexPolicyScript = require('../getIndexPolicyScript');
 const getPartitionKey = require('../getPartitionKey');
+const { getCliShellName } = require('./getCliShellName');
 const {
 	CLI,
 	DATABASE,
@@ -16,7 +17,8 @@ const {
 
 const buildAzureCLIScript =
 	_ =>
-	({ modelData, containerData, shellName }) => {
+	({ modelData, containerData, options }) => {
+		const shellName = getCliShellName(options?.targetScriptOptions);
 		const cliParamsDelimiter = getCliParamsDelimiter(shellName);
 		const escapeAndWrapInQuotes = string => wrapInSingleQuotes(escapeShellCommand(shellName, string));
 

--- a/forward_engineering/helpers/azureCLIScriptHelpers/getCliShellName.js
+++ b/forward_engineering/helpers/azureCLIScriptHelpers/getCliShellName.js
@@ -1,0 +1,12 @@
+/**
+ * @param {object} targetScriptOptions
+ * @returns {string}
+ */
+const getCliShellName = (targetScriptOptions = {}) => {
+	const keyword = targetScriptOptions.keyword ?? '';
+	const [, shellName = ''] = keyword.split('azureCli');
+
+	return shellName.toLowerCase();
+};
+
+module.exports = { getCliShellName };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-7253" title="HCK-7253" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-7253</a>  CosmosDB-SQL: Documentation should be generated correctly with the target script option enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
